### PR TITLE
wallpaper radowm path error

### DIFF
--- a/config/btop/btop.conf
+++ b/config/btop/btop.conf
@@ -2,7 +2,7 @@
 
 #* Name of a btop++/bpytop/bashtop formatted ".theme" file, "Default" and "TTY" for builtin themes.
 #* Themes should be placed in "../share/btop/themes" relative to binary or "$HOME/.config/btop/themes"
-color_theme = "/home/ja/.config/btop/themes/catppuccin_macchiato.theme"
+color_theme = "catppuccin_macchiato.theme"
 
 #* If the theme set background should be shown, set to False if you want terminal background transparency.
 theme_background = False

--- a/config/hypr/scripts/changeWallpaper
+++ b/config/hypr/scripts/changeWallpaper
@@ -15,5 +15,5 @@ if [[ $(pidof swww-daemon) ]]; then
 fi
 
 
-swaybg -m fill -i ${DIR}/${RANDOMPICS}
+swaybg -m fill -i ${RANDOMPICS}
 ## notify-send "${RANDOMPICS}"

--- a/config/hypr/scripts/changeWallpaper2
+++ b/config/hypr/scripts/changeWallpaper2
@@ -12,5 +12,4 @@ fi
 swww query || swww init
 
 #change-wallpaper using swww
-swww img ${DIR}/${RANDOMPICS} --transition-fps 30 --transition-type any --transition-duration 3
-
+swww img ${RANDOMPICS} --transition-fps 30 --transition-type any --transition-duration 3


### PR DESCRIPTION
The path obtained by the `find` command is the full path.